### PR TITLE
Drag&drop

### DIFF
--- a/notesToSelf.txt
+++ b/notesToSelf.txt
@@ -1,0 +1,19 @@
+How drag and drop works in SavedGroupsPage:
+
+1. Initializes state with tasks, an array that contains all the draggable things
+2. Render return:
+  a. Drag container as the root
+  b. A div for each of the sections, in progress and done
+    -These sections each have an event listener for onDragOver and onDrop, which correspond to the methods, onDragover and onDrop
+  c. The children for each section correspond to some javascript above in the render method:
+3. Also in the render method: tasks, an object that contains an array for each section, in progress and done
+4. We will use state to create a div for each of the tasks in state and then push it into one of the arrays in the render method so that it will be rendered in the correct section
+
+
+
+How we make drag and drop work in MakeGroupsPage:
+Switch to category A and category b
+or
+add to state a marker that will tell us which is the primary category, 1 or 2. we'll use this when we process the data to make groups later on. Initially category 1 is the primary but if we end up dropping anything it would switch.
+
+onDragStart = 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -18,7 +18,7 @@ class App extends Component {
     super(props);
     this.state = {
       data: {},
-      groupings: [],
+      // groupings: [],
       studentArr: [],
     }
   }
@@ -33,15 +33,15 @@ class App extends Component {
     ls.set('studentArr', studentArr);
   }
 
-  addGroupings = (groupings) => {
-    this.setState({ groupings: groupings });
-    ls.set('groupings', groupings);
-  }
+  // addGroupings = (groupings) => {
+  //   this.setState({ groupings: groupings });
+  //   ls.set('groupings', groupings);
+  // }
 
-  updateGroupings = (groupings) => {
-    this.setState({ groupings: groupings });
-    ls.set('groupings', groupings);
-  }
+  // updateGroupings = (groupings) => {
+  //   this.setState({ groupings: groupings });
+  //   ls.set('groupings', groupings);
+  // }
 
   render() {
     const { data, groupings } = this.state;

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -18,7 +18,6 @@ class App extends Component {
     super(props);
     this.state = {
       data: {},
-      // groupings: [],
       studentArr: [],
     }
   }
@@ -33,15 +32,10 @@ class App extends Component {
     ls.set('studentArr', studentArr);
   }
 
-  // addGroupings = (groupings) => {
-  //   this.setState({ groupings: groupings });
-  //   ls.set('groupings', groupings);
-  // }
-
-  // updateGroupings = (groupings) => {
-  //   this.setState({ groupings: groupings });
-  //   ls.set('groupings', groupings);
-  // }
+  addCatNames = (primaryCatName, secondaryCatName) => {
+    ls.set('primaryCat', primaryCatName);
+    ls.set('secondaryCat', secondaryCatName);
+  }
 
   render() {
     const { data, groupings } = this.state;
@@ -50,8 +44,8 @@ class App extends Component {
       data,
       groupings,
       addData: this.addData,
-      addGroupings: this.addGroupings,
       addStudentArr: this.addStudentArr,
+      addCatNames: this.addCatNames,
     };
 
     return (

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -6,6 +6,7 @@ import MixEdContext from '../../context/MixEdContext';
 import LandingPage from '../../routes/LandingPage/LandingPage';
 import MakeGroupsPage from '../../routes/MakeGroupsPage/MakeGroupsPage';
 import GroupsMadePage from '../../routes/GroupsMadePage/GroupsMadePage';
+import SavedGroupsPage from '../../routes/SavedGroupsPage/SavedGroupsPage';
 import NavBar from '../NavBar/NavBar';
 
 import ls from 'local-storage';
@@ -70,6 +71,10 @@ class App extends Component {
           <Route
             path="/groups-made"
             component={GroupsMadePage}
+          />
+          <Route
+            path="/my-groups"
+            component={SavedGroupsPage}
           />
         </Switch>
         </MixEdContext.Provider>

--- a/src/context/MixEdContext.js
+++ b/src/context/MixEdContext.js
@@ -4,7 +4,7 @@ const MixEdContext = React.createContext({
   data: {},
   groupings: [],
   addData: () => {},
-  addGroupings: () => {},
+  addCatNames: () => {},
   addStudentArr: () => {},
 });
 

--- a/src/routes/GroupsMadePage/GroupsMadePage.css
+++ b/src/routes/GroupsMadePage/GroupsMadePage.css
@@ -9,6 +9,56 @@
 .groups-made-page__group {
   margin: 10px;
   padding: 10px;
+  border: 1px solid gray;
+  background-color: lightgray;
+  min-width: 200px;
+}
+
+.groups-made-page__student {
+  background-color: whitesmoke;
+  border: 1px solid gray;
+  padding: 5px;
+  margin: 5px;
+}
+
+/* tooltip-specific styles */
+.groups-made-page__student {
+  position: relative;
+}
+
+.groups-made-page__tooltip > p {
+  margin: 0;
+}
+
+.groups-made-page__student .groups-made-page__tooltip {
+  font-size: 0.8em;
+  padding: 5px;
+  color: white;
+  background-color: black;
+  z-index: 1;
+  visibility: hidden;
+  position: absolute;
+  width: 180px;
+  top: 100%;
+  left: 50%;
+  /* half of width + padding * -1 to center */
+  margin-left: -95px;
+  border-radius: 5px;
+}
+
+.groups-made-page__student:hover .groups-made-page__tooltip {
+  visibility: visible;
+}
+
+.groups-made-page__student .groups-made-page__tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent black transparent;
 }
 
 @media screen and (min-width: 700px) {
@@ -18,4 +68,5 @@
     flex-wrap: wrap;
     justify-content: center;
   }
+
 }

--- a/src/routes/GroupsMadePage/GroupsMadePage.jsx
+++ b/src/routes/GroupsMadePage/GroupsMadePage.jsx
@@ -78,7 +78,7 @@ class GroupsMadePage extends Component {
 
   saveGroups = (groupName, groupClass) => {
     const { groupings } = this.state;
-    this.setState({ groupingName: groupName, className: groupClass })
+    // this.setState({ groupingName: groupName, className: groupClass })
     console.log(`saving groups to database under name ${groupName} and class ${groupClass}:`);
     console.log(groupings);
   }

--- a/src/routes/GroupsMadePage/GroupsMadePage.jsx
+++ b/src/routes/GroupsMadePage/GroupsMadePage.jsx
@@ -8,48 +8,38 @@ class GroupsMadePage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      groupings: [],
       show: false,
+      students: [],
+      groups: [],
       groupingName: '',
       className: '',
     }
   }
 
   componentDidMount() {
-    // const { groupings } = this.context;
-    const groupings = ls.get('groupings');
-    console.log(groupings);
-    this.setState({ groupings: groupings });
+    const students = ls.get('studentArr');
+    console.log(students);
+    this.setState({ students: students });
+    this.getGroups(students);
+  }
+
+
+  getGroups = (studentsArr) => {
+    const groupNums = [];
+    // get all the group numbers for all the students and push into arr
+    studentsArr.forEach((student) => {
+      groupNums.push(student.groupNum);
+    })
+    // create array with a set containing only unique items
+    const groups = Array.from(new Set(groupNums));
+    groups.sort((a, b) => a - b);
+    this.setState({ groups: groups });
+    console.log(groups);
   }
 
   handleSubmit = (e) => {
     e.preventDefault();
-    this.matchExistingAlias();
     this.showSaveModal();
-  }
-
-  matchExistingAlias = () => {
-    const studentArr = ls.get('studentArr');
-    const { groupings } = this.state;
-    const indexesToCheck = [];
-    groupings.forEach((arr, idx) => {
-      arr.forEach((el, i) => {
-        if (typeof el !== 'object') {
-          indexesToCheck.push([idx, i]);
-        }
-      })
-    })
-    // console.log(indexesToCheck);
-    indexesToCheck.forEach((indexes) => {
-      const str = groupings[indexes[0]][indexes[1]];
-      studentArr.forEach((stuObj) => {
-        if (stuObj.alias === str) {
-          groupings[indexes[0]].splice(indexes[1], 1, stuObj);
-        }
-      })
-    })
-    this.setState({ groupings: groupings});
-    console.log('matchExistingAlias ran');
   }
 
   handleClickCancel = () => {
@@ -61,12 +51,6 @@ class GroupsMadePage extends Component {
     const { history } = this.props;
     history.goBack();
   }
-
-  updateStudent = (groupIndex, studentIndex, e) => {
-    const { groupings } = this.state;
-    groupings[groupIndex].splice(studentIndex, 1, e.target.value);
-    this.setState({ groupings: groupings });
-  }
   
   showSaveModal = () => {
     this.setState({ show: true });
@@ -76,36 +60,76 @@ class GroupsMadePage extends Component {
     this.setState({ show: false });
   }
 
-  saveGroups = (groupName, groupClass) => {
-    const { groupings } = this.state;
-    // this.setState({ groupingName: groupName, className: groupClass })
-    console.log(`saving groups to database under name ${groupName} and class ${groupClass}:`);
-    console.log(groupings);
+  saveGroups = (groupingName, className) => {
+    // currently this isn't really functional but we do update the students in local storage at this point
+    this.setState({ groupingName, className });
+    const { students } = this.state;
+    const { addStudentArr } = this.context;
+    addStudentArr(students);
+    console.log(`saving groups to database under name ${groupingName} and class ${className}`);
+  }
+
+  handleDragStart = (event, student) => {
+    event.dataTransfer.setData("student", student);
+  }
+
+  onDragOver = (event) => {
+    event.preventDefault();
+  }
+
+  handleDrop = (event, newGroup) => {
+    const { students } = this.state;
+    const draggedStudent = event.dataTransfer.getData("student");
+    // then set state for students
+    let updatedStudent = students.filter((student) => {
+      if (draggedStudent === student.alias) {
+        student.groupNum = newGroup;
+      }
+      return student;
+    })
+    this.setState({ ...this.state, updatedStudent });
   }
 
   render() {
-    const { groupings, show } = this.state;
-    const showGroupings = groupings.map((group, idx) => (
-      <fieldset key={idx + 1} className="groups-made-page__group">
-        <legend>Group {idx + 1}</legend>
-          {group.map((stu, i) => (
-            <div key={(idx + 1) + '-' + (i + 1)}>
-            <input 
-              name={'group' + (idx + 1) + '-' + (i + 1)}
-              id={'group' + (idx + 1) + '-' + (i + 1)}
-              defaultValue={stu.alias}
-              onChange={(e) => this.updateStudent(idx, i, e)}
-            />
-            </div>
-          ))}
-          
-      </fieldset>
-    ))
+    const { show, groups, students } = this.state;
+    const primaryCat = ls.get('primaryCat');
+    const secondaryCat = ls.get('secondaryCat');
+    const showGroupings = (
+      groups.map((group) => (
+        <div
+          key={group}
+          className="groups-made-page__group"
+          onDragOver={(event) => this.onDragOver(event)}
+          onDrop={(event) => {this.handleDrop(event, group)}}
+        >
+          Group {group}
+          {students.map((student, idx) => {
+            if (student.groupNum === group) {
+              return (
+                <div 
+                  key={idx + 1}
+                  className="groups-made-page__student"
+                  onDragStart={(event) => {this.handleDragStart(event, student.alias)}}
+                  draggable
+                >
+                  {student.alias}
+                <div className="groups-made-page__tooltip">
+                  <p>{`${primaryCat}: ${student[primaryCat]}`}</p>
+                  <p>{`${secondaryCat}: ${student[secondaryCat]}`}</p>
+                </div>
+                </div>
+              )
+            }
+            return '';
+          })}
+        </div>
+      )
+    ));
 
     return (
       <main className="groups-made-page">
         <h1>Groupings</h1>
-        <p>Click on a student to edit the group</p>
+        <p>Drag and drop students to rearrange groups.</p>
         <form className="groups-made-page__form" onSubmit={this.handleSubmit}>
           <div className="groups-made-page__groupings">
           {showGroupings}

--- a/src/routes/MakeGroupsPage/MakeGroupsPage.css
+++ b/src/routes/MakeGroupsPage/MakeGroupsPage.css
@@ -13,3 +13,8 @@
     display: flex;
   }
 }
+
+.make-groups-page__aliases {
+  position: relative;
+  bottom: -65px;
+}

--- a/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
+++ b/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
@@ -265,225 +265,124 @@ class MakeGroupsPage extends Component {
   }
 
   render() {
+    const category1 = (
+      <div
+        className="make-groups-page__category--one"
+        onDragStart={(event) => this.onDragStart(event, "category1")}
+        draggable
+      >
+        <div>
+          <ValidationError message={this.validateNumbersCat1()} />
+        </div>
+        <div>
+          <input
+            name="cat1-type"
+            id="cat1-quantitative"
+            value="quantitative"
+            type="radio"
+            checked={this.state.cat1Type === 'quantitative'}
+            onChange={this.updateCat1Type}
+            required
+          />
+          <label htmlFor="cat1-quantitative">Quantitative (numbers)</label>
+          <input
+            name="cat1-type"
+            id="cat1-qualitative"
+            value="qualitative"
+            type="radio"
+            checked={this.state.cat1Type === 'qualitative'}
+            onChange={this.updateCat1Type}
+            required
+          />
+          <label htmlFor="cat1-qualitative">Qualitative (words)</label>
+        </div>
+        <div>
+          <label htmlFor="cat1-name">Category name:</label>{' '}
+          <input
+            name="cat1-name"
+            id="cat1-name"
+            type="text"
+            value={this.state.cat1Name}
+            onChange={this.updateCat1Name}
+          />
+        </div>
+        <div>
+          <textarea
+            id="cat1-vals"
+            name="cat1-vals"
+            rows="26"
+            columns="20"
+            placeholder="Enter values here, one on each line."
+            value={this.state.cat1Vals}
+            onChange={this.updateCat1Vals}
+          />
+        </div>
+      </div>
+    );
+    const category2 = (
+      <div
+        className="make-groups-page__category--two"
+        onDragStart={(event) => this.onDragStart(event, "category2")}
+        draggable
+      >
+        <div>
+          <ValidationError message={this.validateNumbersCat2()} />
+          {/* <ValidationError message={this.validateCat2Vals()} /> */}
+        </div>
+        <div>
+          <input
+            name="cat2-type"
+            id="cat2-quantitative"
+            value="quantitative"
+            type="radio"
+            checked={this.state.cat2Type === 'quantitative'}
+            onChange={this.updateCat2Type}
+            required
+          />
+          <label htmlFor="cat2-quantitative">Quantitative (numbers)</label>
+          <input
+            name="cat2-type"
+            id="cat2-qualitative"
+            value="qualitative"
+            type="radio"
+            checked={this.state.cat2Type === 'qualitative'}
+            onChange={this.updateCat2Type}
+            required
+          />
+          <label htmlFor="cat2-qualitative">Qualitative (words)</label>
+        </div>
+        <div>
+          <label htmlFor="cat2-name">Category name:</label>{' '}
+          <input
+            name="cat2-name"
+            id="cat2-name"
+            type="text"
+            value={this.state.cat2Name}
+            onChange={this.updateCat2Name}
+          />
+        </div>
+        <div>
+          <textarea
+            id="cat2-vals"
+            name="cat2-vals"
+            rows="26"
+            columns="20"
+            placeholder="Enter values here, one on each line."
+            value={this.state.cat2Vals}
+            onChange={this.updateCat2Vals}
+          />
+        </div>
+      </div>
+    );
     let primaryCategory;
     let secondaryCategory;
     const { primaryCat } = this.state;
     if (primaryCat === 'cat1') {
-      primaryCategory = (
-        <div
-          className="category1"
-          onDragStart={(event) => this.onDragStart(event, "category1")}
-          draggable
-        >
-          <div>
-            <ValidationError message={this.validateNumbersCat1()} />
-          </div>
-          <div>
-            <input
-              name="cat1-type"
-              id="cat1-quantitative"
-              value="quantitative"
-              type="radio"
-              checked={this.state.cat1Type === 'quantitative'}
-              onChange={this.updateCat1Type}
-              required
-            />
-            <label htmlFor="cat1-quantitative">Quantitative (numbers)</label>
-            <input
-              name="cat1-type"
-              id="cat1-qualitative"
-              value="qualitative"
-              type="radio"
-              checked={this.state.cat1Type === 'qualitative'}
-              onChange={this.updateCat1Type}
-            />
-            <label htmlFor="cat1-qualitative">Qualitative (words)</label>
-          </div>
-          <div>
-            <label htmlFor="cat1-name">Category name:</label>{' '}
-            <input
-              name="cat1-name"
-              id="cat1-name"
-              type="text"
-              value={this.state.cat1Name}
-              onChange={this.updateCat1Name}
-            />
-          </div>
-          <div>
-            <textarea
-              id="cat1-vals"
-              name="cat1-vals"
-              rows="26"
-              columns="20"
-              placeholder="Enter values here, one on each line."
-              value={this.state.cat1Vals}
-              onChange={this.updateCat1Vals}
-            />
-          </div>
-        </div>
-      );
-      secondaryCategory = (
-        <div
-          className="category2"
-          onDragStart={(event) => this.onDragStart(event, "category1")}
-          draggable
-        >
-          <div>
-            <ValidationError message={this.validateNumbersCat2()} />
-            <ValidationError message={this.validateCat2Vals()} />
-          </div>
-          <div>
-  
-            <input
-              name="cat2-type"
-              id="cat2-quantitative"
-              value="quantitative"
-              type="radio"
-              checked={this.state.cat2Type === 'quantitative'}
-              onChange={this.updateCat2Type}
-            />
-            <label htmlFor="cat2-quantitative">Quantitative (numbers)</label>
-            <input
-              name="cat2-type"
-              id="cat2-qualitative"
-              value="qualitative"
-              type="radio"
-              checked={this.state.cat2Type === 'qualitative'}
-              onChange={this.updateCat2Type}
-            />
-            <label htmlFor="cat2-qualitative">Qualitative (words)</label>
-          </div>
-          <div>
-            <label htmlFor="cat2-name">Category name:</label>{' '}
-            <input
-              name="cat2-name"
-              id="cat2-name"
-              type="text"
-              value={this.state.cat2Name}
-              onChange={this.updateCat2Name}
-            />
-          </div>
-          <div>
-            <textarea
-              id="cat2-vals"
-              name="cat2-vals"
-              rows="26"
-              columns="20"
-              placeholder="Enter values here, one on each line."
-              value={this.state.cat2Vals}
-              onChange={this.updateCat2Vals}
-            />
-          </div>
-        </div>
-      );
+      primaryCategory = category1;
+      secondaryCategory = category2;
     } else {
-      secondaryCategory = (
-        <div
-          className="category1"
-          onDragStart={(event) => this.onDragStart(event, "category1")}
-          draggable
-        >
-          <div>
-            <ValidationError message={this.validateNumbersCat1()} />
-          </div>
-          <div>
-            <input
-              name="cat1-type"
-              id="cat1-quantitative"
-              value="quantitative"
-              type="radio"
-              checked={this.state.cat1Type === 'quantitative'}
-              onChange={this.updateCat1Type}
-              required
-            />
-            <label htmlFor="cat1-quantitative">Quantitative (numbers)</label>
-            <input
-              name="cat1-type"
-              id="cat1-qualitative"
-              value="qualitative"
-              type="radio"
-              checked={this.state.cat1Type === 'qualitative'}
-              onChange={this.updateCat1Type}
-            />
-            <label htmlFor="cat1-qualitative">Qualitative (words)</label>
-          </div>
-          <div>
-            <label htmlFor="cat1-name">Category name:</label>{' '}
-            <input
-              name="cat1-name"
-              id="cat1-name"
-              type="text"
-              value={this.state.cat1Name}
-              onChange={this.updateCat1Name}
-            />
-          </div>
-          <div>
-            <textarea
-              id="cat1-vals"
-              name="cat1-vals"
-              rows="26"
-              columns="20"
-              placeholder="Enter values here, one on each line."
-              value={this.state.cat1Vals}
-              onChange={this.updateCat1Vals}
-            />
-          </div>
-        </div>
-      );
-      primaryCategory = (
-        <div
-          className="category2"
-          onDragStart={(event) => this.onDragStart(event, "category1")}
-          draggable
-        >
-          <div>
-            <ValidationError message={this.validateNumbersCat2()} />
-            <ValidationError message={this.validateCat2Vals()} />
-          </div>
-          <div>
-  
-            <input
-              name="cat2-type"
-              id="cat2-quantitative"
-              value="quantitative"
-              type="radio"
-              checked={this.state.cat2Type === 'quantitative'}
-              onChange={this.updateCat2Type}
-            />
-            <label htmlFor="cat2-quantitative">Quantitative (numbers)</label>
-            <input
-              name="cat2-type"
-              id="cat2-qualitative"
-              value="qualitative"
-              type="radio"
-              checked={this.state.cat2Type === 'qualitative'}
-              onChange={this.updateCat2Type}
-            />
-            <label htmlFor="cat2-qualitative">Qualitative (words)</label>
-          </div>
-          <div>
-            <label htmlFor="cat2-name">Category name:</label>{' '}
-            <input
-              name="cat2-name"
-              id="cat2-name"
-              type="text"
-              value={this.state.cat2Name}
-              onChange={this.updateCat2Name}
-            />
-          </div>
-          <div>
-            <textarea
-              id="cat2-vals"
-              name="cat2-vals"
-              rows="26"
-              columns="20"
-              placeholder="Enter values here, one on each line."
-              value={this.state.cat2Vals}
-              onChange={this.updateCat2Vals}
-            />
-          </div>
-        </div>
-      );
+      secondaryCategory = category1;
+      primaryCategory = category2;
     }
 
     return (
@@ -525,23 +424,25 @@ class MakeGroupsPage extends Component {
             </div>
           </fieldset>
           <div className="make-groups-page__form--student-data">
-            <fieldset>
+            <fieldset className="make-groups-page__alias-section">
               <legend>Alias (list of names or other identifier):</legend>
               <div>
                 <ValidationError message={this.validateAliases()} />
                 <ValidationError message={this.validateDataSize()} />
               </div>
-              <textarea
-                id="aliases"
-                name="aliases"
-                rows="26"
-                columns="20"
-                placeholder="Enter aliases here, one on each line."
-                value={this.state.aliases}
-                onChange={this.updateAliases}
-              />
+              <div className="make-groups-page__aliases">
+                <textarea
+                  id="aliases"
+                  name="aliases"
+                  rows="26"
+                  columns="20"
+                  placeholder="Enter aliases here, one on each line."
+                  value={this.state.aliases}
+                  onChange={this.updateAliases}
+                />
+              </div>
             </fieldset>
-            <fieldset>
+            <fieldset className="make-groups-page__primary-section">
               <legend>Primary category:</legend>
               <div
                 onDragOver={(event) => this.onDragOver(event)}
@@ -551,7 +452,7 @@ class MakeGroupsPage extends Component {
                 {primaryCategory}
               </div>
             </fieldset>
-            <fieldset>
+            <fieldset className="make-groups-page__secondary-section">
               <legend>Secondary category:</legend>
               <div
                 onDragOver={(event) => this.onDragOver(event)}

--- a/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
+++ b/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
@@ -56,8 +56,8 @@ class MakeGroupsPage extends Component {
     addData(this.state);
 
     // create arrays with category values, trimming whitespace
-    let cat1ValsArray = cat1Vals.split(`\n`).filter((val) => !!val.trim().length);
-    let cat2ValsArray = cat2Vals.split(`\n`).filter((val) => !!val.trim().length);
+    let cat1ValsArray = this.createTrimmedArr(cat1Vals);
+    let cat2ValsArray = this.createTrimmedArr(cat2Vals);
     // convert any numerical categories to numbers
     if (cat1Type === 'quantitative') {
       cat1ValsArray = cat1ValsArray.map((val) => Number(val));
@@ -67,7 +67,7 @@ class MakeGroupsPage extends Component {
     }
     // create an arr of objs where each student with their data is an obj, add students and values
     const mixedStudentArray = [];
-    const aliasesArray = aliases.split(`\n`).filter((val) => !!val.trim().length);
+    const aliasesArray = this.createTrimmedArr(aliases);
     aliasesArray.forEach((alias) => mixedStudentArray.push({ alias: alias }));
     MakeGroupsService.addEachToObj(mixedStudentArray, cat1ValsArray, cat1Name);
     MakeGroupsService.addEachToObj(mixedStudentArray, cat2ValsArray, cat2Name);
@@ -108,6 +108,8 @@ class MakeGroupsPage extends Component {
     }
     history.push('/groups-made')
   }
+
+  createTrimmedArr = (vals) => vals.split(`\n`).filter((val) => !!val.trim().length);
 
   updateGroupSize = (e) => {
     this.setState({ groupSize: e.target.value });
@@ -176,27 +178,10 @@ class MakeGroupsPage extends Component {
     }
   }
 
-  // the required attribute in the radio input takes care of this, but a message on submit would be nice
-  // validateGroupingType = () => {
-  //   // Check that grouping type has been selected (RADIO)
-  //   const { groupingType } = this.state;
-  //   if (groupingType !== ('similar' || 'mixed')) {
-  //     return 'Grouping type is required'
-  //   }
-  // }
-
-  // validateDataTypeCat = () => {
-  //   // Check that data type has been selected for each (RADIO) as long as there is also data in the textarea
-  //   const { cat1Type } = this.state;
-  //   if (cat1Type !== ('quantitative' || 'qualitative')) {
-  //     return 'Data type is required'
-  //   }
-  // }
-
   validateNumbersCat1 = () => {
     const { cat1Vals } = this.state;
     const { cat1Type } = this.state;
-    const cat1ValsArray = cat1Vals.split(`\n`).filter((val) => !!val.trim().length);
+    const cat1ValsArray = this.createTrimmedArr(cat1Vals);
     if (cat1Type === 'quantitative') {
       const cat1NumbersArray = cat1ValsArray.map((val) => Number(val));
       if (cat1NumbersArray.includes(NaN)) {
@@ -208,7 +193,7 @@ class MakeGroupsPage extends Component {
   validateNumbersCat2 = () => {
     const { cat2Vals } = this.state;
     const { cat2Type } = this.state;
-    const cat2ValsArray = cat2Vals.split(`\n`).filter((val) => !!val.trim().length);
+    const cat2ValsArray = this.createTrimmedArr(cat2Vals);
     if (cat2Type === 'quantitative') {
       const cat2NumbersArray = cat2ValsArray.map((val) => Number(val));
       if (cat2NumbersArray.includes(NaN)) {
@@ -263,9 +248,6 @@ class MakeGroupsPage extends Component {
             onChange={this.updateGroupSize}
           />
           <div>
-            {/* <div>
-              <ValidationError message={this.validateGroupingType()} />
-            </div> */}
             <input 
               name="grouping-type"
               id="grouping-similar"
@@ -307,7 +289,6 @@ class MakeGroupsPage extends Component {
         <fieldset>
           <legend>Primary category:</legend>
           <div>
-              {/* <ValidationError message={this.validateDataTypeCat()} /> */}
               <ValidationError message={this.validateNumbersCat1()} />
             </div>
           <div>
@@ -356,7 +337,6 @@ class MakeGroupsPage extends Component {
         <fieldset>
           <legend>Secondary category:</legend>
           <div>
-              {/* <ValidationError message={this.validateDataTypeCat()} /> */}
               <ValidationError message={this.validateNumbersCat2()} />
               <ValidationError message={this.validateCat2Vals()} />
             </div>

--- a/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
+++ b/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
@@ -93,23 +93,34 @@ class MakeGroupsPage extends Component {
 
 
     if (groupingType === 'mixed') {
-      // TODO: reorder the array so that most frequent groups appear first
-      addStudentArr(mixedStudentArray);
       const groups = createDifferentGroups(mixedStudentArray, groupSize, cat1Name, cat2Name);
-      addGroupings(groups);
-      // console.log(groups);
+      this.addGroupNum(groups, mixedStudentArray);
+      addStudentArr(mixedStudentArray);
     }
     if (groupingType === 'similar') {
-
-      addStudentArr(mixedStudentArray);
       const groups = createSimilarGroups(mixedStudentArray, groupSize, cat1Name, cat2Name);
-      addGroupings(groups);
-      // console.log(groups);
+      this.addGroupNum(groups, mixedStudentArray);
+      addStudentArr(mixedStudentArray);
     }
     history.push('/groups-made')
   }
 
   createTrimmedArr = (vals) => vals.split(`\n`).filter((val) => !!val.trim().length);
+
+  addGroupNum = (groupArr, studentArr) => {
+    // goes through the array elements of groups
+    // within each innermost array, finds the student in the mixedStudentArray
+    // adds their groupNumber (index of the outer array + 1) as a property
+    groupArr.forEach((group, index) => {
+      group.forEach((groupMem) => {
+        studentArr.forEach((student) => {
+          if (student.alias === groupMem.alias) {
+            student.groupNum = (index + 1);
+          }
+        })
+      })
+    });
+  }
 
   updateGroupSize = (e) => {
     this.setState({ groupSize: e.target.value });
@@ -244,7 +255,6 @@ class MakeGroupsPage extends Component {
             min="2"
             max="20"
             defaultValue="2"
-            // TODO: ensure this is appropriately bound, if not this.updateGroupSize.bind(this) may work better
             onChange={this.updateGroupSize}
           />
           <div>

--- a/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
+++ b/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
@@ -7,7 +7,7 @@ import ValidationError from '../../components/ValidationError/ValidationError';
 import './MakeGroupsPage.css';
 
 import createDifferentGroups from '../../services/groupingAlgorithms/differentGroups';
-import createSimilarGroups from '../../services/groupingAlgorithms/similarGroups'; 
+import createSimilarGroups from '../../services/groupingAlgorithms/similarGroups';
 import MakeGroupsService from '../../services/make-groups-service';
 import store from '../../services/store';
 
@@ -27,6 +27,8 @@ class MakeGroupsPage extends Component {
       cat1Vals: '',
       cat2Name: '',
       cat2Vals: '',
+      primaryCat: 'cat1',
+
     }
   }
 
@@ -39,10 +41,9 @@ class MakeGroupsPage extends Component {
 
   handleSubmit = (e) => {
     e.preventDefault();
-    const { addData, addStudentArr, addGroupings } = this.context;
+    const { addData, addStudentArr } = this.context;
     const { history } = this.props;
-    // console.log('pretending to submit form');
-    const { 
+    const {
       groupSize,
       groupingType,
       cat1Type,
@@ -52,53 +53,58 @@ class MakeGroupsPage extends Component {
       cat1Vals,
       cat2Name,
       cat2Vals,
+      primaryCat,
     } = this.state;
     addData(this.state);
 
-    // create arrays with category values, trimming whitespace
-    let cat1ValsArray = this.createTrimmedArr(cat1Vals);
-    let cat2ValsArray = this.createTrimmedArr(cat2Vals);
+    let primaryValsArr = primaryCat === 'cat1' ? this.createTrimmedArr(cat1Vals) : this.createTrimmedArr(cat2Vals);
+    let secondaryValsArr = primaryCat === 'cat1' ? this.createTrimmedArr(cat2Vals) : this.createTrimmedArr(cat1Vals);
+    const primaryCatName = primaryCat === 'cat1' ? cat1Name : cat2Name;
+    const secondaryCatName = primaryCat === 'cat1' ? cat2Name : cat1Name;
+    const primaryCatType = primaryCat === 'cat1' ? cat1Type : cat2Type;
+    const secondaryCatType = primaryCat === 'cat1' ? cat2Type: cat1Type;
+
     // convert any numerical categories to numbers
     if (cat1Type === 'quantitative') {
-      cat1ValsArray = cat1ValsArray.map((val) => Number(val));
+      primaryValsArr = primaryValsArr.map((val) => Number(val));
     }
     if (cat2Type === 'quantitative') {
-      cat2ValsArray = cat2ValsArray.map((val) => Number(val));
+      secondaryValsArr = secondaryValsArr.map((val) => Number(val));
     }
     // create an arr of objs where each student with their data is an obj, add students and values
     const mixedStudentArray = [];
     const aliasesArray = this.createTrimmedArr(aliases);
     aliasesArray.forEach((alias) => mixedStudentArray.push({ alias: alias }));
-    MakeGroupsService.addEachToObj(mixedStudentArray, cat1ValsArray, cat1Name);
-    MakeGroupsService.addEachToObj(mixedStudentArray, cat2ValsArray, cat2Name);
+    MakeGroupsService.addEachToObj(mixedStudentArray, primaryValsArr, primaryCatName);
+    MakeGroupsService.addEachToObj(mixedStudentArray, secondaryValsArr, secondaryCatName);
 
-    
+
     // if dealing with quantitative data, also separate into categorizable levels
     // (number of levels determined by group size)
     // and then add the level to the student object for any quantitative category
     // let createGroupsWith = [];
-    if (cat1Type === 'quantitative') {
-      const studentScoreLevel = MakeGroupsService.getLevel(cat1ValsArray, groupSize);
-      MakeGroupsService.addEachToObj(mixedStudentArray, studentScoreLevel, cat1Name + ' Level');
+    if (primaryCatType === 'quantitative') {
+      const studentScoreLevel = MakeGroupsService.getLevel(primaryValsArr, groupSize);
+      MakeGroupsService.addEachToObj(mixedStudentArray, studentScoreLevel, primaryCat + ' Level');
       // createGroupsWith = [...mixedStudentArray]
     }
     // if (cat1Type === 'qualitative') {
     //   // reorder values
     //   createGroupsWith = MakeGroupsService.mostFrequentFirst(mixedStudentArray, cat1Name);
     // }
-    if (cat2Type === 'quantitative') {
-      const studentScoreLevel = MakeGroupsService.getLevel(cat2ValsArray, groupSize);
-      MakeGroupsService.addEachToObj(mixedStudentArray, studentScoreLevel, cat2Name + ' Level')
+    if (secondaryCatType === 'quantitative') {
+      const studentScoreLevel = MakeGroupsService.getLevel(secondaryValsArr, groupSize);
+      MakeGroupsService.addEachToObj(mixedStudentArray, studentScoreLevel, secondaryCatName + ' Level')
     }
 
 
     if (groupingType === 'mixed') {
-      const groups = createDifferentGroups(mixedStudentArray, groupSize, cat1Name, cat2Name);
+      const groups = createDifferentGroups(mixedStudentArray, groupSize, primaryCatName, secondaryCatName);
       this.addGroupNum(groups, mixedStudentArray);
       addStudentArr(mixedStudentArray);
     }
     if (groupingType === 'similar') {
-      const groups = createSimilarGroups(mixedStudentArray, groupSize, cat1Name, cat2Name);
+      const groups = createSimilarGroups(mixedStudentArray, groupSize, primaryCatName, secondaryCatName);
       this.addGroupNum(groups, mixedStudentArray);
       addStudentArr(mixedStudentArray);
     }
@@ -177,11 +183,11 @@ class MakeGroupsPage extends Component {
     const cat2ValsArray = cat2Vals.split(`\n`).filter((val) => !!val.trim().length);
 
     // checks for 3 valid conditions:
-      // 1. if there are only aliases in the form (then will just make random groups)
-      // 2. if there are aliases & category 1 values, and each has the same number of lines (then will only work with one category)
-      // 3. if aliases and both categories are filled in, and each has the same number of lines (then will take into consideration both categories)
+    // 1. if there are only aliases in the form (then will just make random groups)
+    // 2. if there are aliases & category 1 values, and each has the same number of lines (then will only work with one category)
+    // 3. if aliases and both categories are filled in, and each has the same number of lines (then will take into consideration both categories)
     const aliasesOnlyCondition = !cat1ValsArray[0] && !cat2ValsArray[0]; // stays true as long as nothing is in categories
-    const aliasesAndCat1Vals = !cat2ValsArray[0] && (aliasesArray.length === cat1ValsArray.length); 
+    const aliasesAndCat1Vals = !cat2ValsArray[0] && (aliasesArray.length === cat1ValsArray.length);
     const aliasesAndAllCats = aliasesArray.length === cat1ValsArray.length && cat1ValsArray.length === cat2ValsArray.length;
     // as long as one of the conditions is true, no validation message
     if (!(aliasesOnlyCondition || aliasesAndCat1Vals || aliasesAndAllCats)) {
@@ -226,7 +232,7 @@ class MakeGroupsPage extends Component {
     const { aliases } = this.state;
     const { groupSize } = this.state;
     const aliasesArray = aliases.split(`\n`).filter((val) => !!val.trim().length);
-    if (aliasesArray.length/groupSize < 2) {
+    if (aliasesArray.length / groupSize < 2) {
       return `More aliases required in order to make groups of size ${groupSize}`;
     }
   }
@@ -240,67 +246,38 @@ class MakeGroupsPage extends Component {
     history.goBack();
   }
 
+  onDragStart = (event, catName) => {
+    event.dataTransfer.setData("catName", catName);
+  }
+
+  onDragOver = (event) => {
+    event.preventDefault();
+  }
+
+  onDrop = () => {
+    console.log('dropping')
+    const { primaryCat } = this.state;
+    if (primaryCat === 'cat1') {
+      this.setState({ primaryCat: 'cat2' })
+    } else {
+      this.setState({ primaryCat: 'cat1' })
+    }
+  }
+
   render() {
-    return (
-      <main className="make-groups-page">
-        <h1>Group Generator</h1>  
-        <form className="make-groups-page__form" onSubmit={this.handleSubmit}>
-        <fieldset>
-          <legend>Grouping characteristics:</legend>
-          <label htmlFor="group-size">Group size (minimum):</label>
-          <input
-            name="group-size"
-            id="group-size"
-            type="number"
-            min="2"
-            max="20"
-            defaultValue="2"
-            onChange={this.updateGroupSize}
-          />
+    let primaryCategory;
+    let secondaryCategory;
+    const { primaryCat } = this.state;
+    if (primaryCat === 'cat1') {
+      primaryCategory = (
+        <div
+          className="category1"
+          onDragStart={(event) => this.onDragStart(event, "category1")}
+          draggable
+        >
           <div>
-            <input 
-              name="grouping-type"
-              id="grouping-similar"
-              value="similar"
-              type="radio"
-              checked={this.state.groupingType === 'similar'}
-              onChange={this.updateGroupingType}
-              required
-            />
-            <label htmlFor="grouping-similar">Group members are similar</label>
-            <input
-              name="grouping-type"
-              id="grouping-mixed"
-              value="mixed"
-              type="radio"
-              checked={this.state.groupingType === 'mixed'}
-              onChange={this.updateGroupingType}
-            />
-            <label htmlFor="grouping-mixed">Group members are diverse</label>
+            <ValidationError message={this.validateNumbersCat1()} />
           </div>
-        </fieldset>
-        <div className="make-groups-page__form--student-data">
-        <fieldset>
-          <legend>Alias (list of names or other identifier):</legend>
-          <div>
-            <ValidationError message={this.validateAliases()} />
-            <ValidationError message={this.validateDataSize()} />
-          </div>
-          <textarea
-              id="aliases"
-              name="aliases"
-              rows="26"
-              columns="20"
-              placeholder="Enter aliases here, one on each line."
-              value={this.state.aliases}
-              onChange={this.updateAliases}
-            />
-        </fieldset>
-        <fieldset>
-          <legend>Primary category:</legend>
-          <div>
-              <ValidationError message={this.validateNumbersCat1()} />
-            </div>
           <div>
             <input
               name="cat1-type"
@@ -323,15 +300,15 @@ class MakeGroupsPage extends Component {
             <label htmlFor="cat1-qualitative">Qualitative (words)</label>
           </div>
           <div>
-              <label htmlFor="cat1-name">Category name:</label>{' '}
-              <input
-                name="cat1-name"
-                id="cat1-name"
-                type="text"
-                value={this.state.cat1Name}
-                onChange={this.updateCat1Name}
-              />
-            </div>
+            <label htmlFor="cat1-name">Category name:</label>{' '}
+            <input
+              name="cat1-name"
+              id="cat1-name"
+              type="text"
+              value={this.state.cat1Name}
+              onChange={this.updateCat1Name}
+            />
+          </div>
           <div>
             <textarea
               id="cat1-vals"
@@ -343,15 +320,20 @@ class MakeGroupsPage extends Component {
               onChange={this.updateCat1Vals}
             />
           </div>
-        </fieldset>
-        <fieldset>
-          <legend>Secondary category:</legend>
+        </div>
+      );
+      secondaryCategory = (
+        <div
+          className="category2"
+          onDragStart={(event) => this.onDragStart(event, "category1")}
+          draggable
+        >
           <div>
-              <ValidationError message={this.validateNumbersCat2()} />
-              <ValidationError message={this.validateCat2Vals()} />
-            </div>
+            <ValidationError message={this.validateNumbersCat2()} />
+            <ValidationError message={this.validateCat2Vals()} />
+          </div>
           <div>
-
+  
             <input
               name="cat2-type"
               id="cat2-quantitative"
@@ -359,7 +341,7 @@ class MakeGroupsPage extends Component {
               type="radio"
               checked={this.state.cat2Type === 'quantitative'}
               onChange={this.updateCat2Type}
-              />
+            />
             <label htmlFor="cat2-quantitative">Quantitative (numbers)</label>
             <input
               name="cat2-type"
@@ -372,17 +354,17 @@ class MakeGroupsPage extends Component {
             <label htmlFor="cat2-qualitative">Qualitative (words)</label>
           </div>
           <div>
-              <label htmlFor="cat2-name">Category name:</label>{' '}
-              <input
-                name="cat2-name"
-                id="cat2-name"
-                type="text"
-                value={this.state.cat2Name}
-                onChange={this.updateCat2Name}
-              />
-            </div>
+            <label htmlFor="cat2-name">Category name:</label>{' '}
+            <input
+              name="cat2-name"
+              id="cat2-name"
+              type="text"
+              value={this.state.cat2Name}
+              onChange={this.updateCat2Name}
+            />
+          </div>
           <div>
-          <textarea
+            <textarea
               id="cat2-vals"
               name="cat2-vals"
               rows="26"
@@ -392,8 +374,194 @@ class MakeGroupsPage extends Component {
               onChange={this.updateCat2Vals}
             />
           </div>
-        </fieldset>
         </div>
+      );
+    } else {
+      secondaryCategory = (
+        <div
+          className="category1"
+          onDragStart={(event) => this.onDragStart(event, "category1")}
+          draggable
+        >
+          <div>
+            <ValidationError message={this.validateNumbersCat1()} />
+          </div>
+          <div>
+            <input
+              name="cat1-type"
+              id="cat1-quantitative"
+              value="quantitative"
+              type="radio"
+              checked={this.state.cat1Type === 'quantitative'}
+              onChange={this.updateCat1Type}
+              required
+            />
+            <label htmlFor="cat1-quantitative">Quantitative (numbers)</label>
+            <input
+              name="cat1-type"
+              id="cat1-qualitative"
+              value="qualitative"
+              type="radio"
+              checked={this.state.cat1Type === 'qualitative'}
+              onChange={this.updateCat1Type}
+            />
+            <label htmlFor="cat1-qualitative">Qualitative (words)</label>
+          </div>
+          <div>
+            <label htmlFor="cat1-name">Category name:</label>{' '}
+            <input
+              name="cat1-name"
+              id="cat1-name"
+              type="text"
+              value={this.state.cat1Name}
+              onChange={this.updateCat1Name}
+            />
+          </div>
+          <div>
+            <textarea
+              id="cat1-vals"
+              name="cat1-vals"
+              rows="26"
+              columns="20"
+              placeholder="Enter values here, one on each line."
+              value={this.state.cat1Vals}
+              onChange={this.updateCat1Vals}
+            />
+          </div>
+        </div>
+      );
+      primaryCategory = (
+        <div
+          className="category2"
+          onDragStart={(event) => this.onDragStart(event, "category1")}
+          draggable
+        >
+          <div>
+            <ValidationError message={this.validateNumbersCat2()} />
+            <ValidationError message={this.validateCat2Vals()} />
+          </div>
+          <div>
+  
+            <input
+              name="cat2-type"
+              id="cat2-quantitative"
+              value="quantitative"
+              type="radio"
+              checked={this.state.cat2Type === 'quantitative'}
+              onChange={this.updateCat2Type}
+            />
+            <label htmlFor="cat2-quantitative">Quantitative (numbers)</label>
+            <input
+              name="cat2-type"
+              id="cat2-qualitative"
+              value="qualitative"
+              type="radio"
+              checked={this.state.cat2Type === 'qualitative'}
+              onChange={this.updateCat2Type}
+            />
+            <label htmlFor="cat2-qualitative">Qualitative (words)</label>
+          </div>
+          <div>
+            <label htmlFor="cat2-name">Category name:</label>{' '}
+            <input
+              name="cat2-name"
+              id="cat2-name"
+              type="text"
+              value={this.state.cat2Name}
+              onChange={this.updateCat2Name}
+            />
+          </div>
+          <div>
+            <textarea
+              id="cat2-vals"
+              name="cat2-vals"
+              rows="26"
+              columns="20"
+              placeholder="Enter values here, one on each line."
+              value={this.state.cat2Vals}
+              onChange={this.updateCat2Vals}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <main className="make-groups-page">
+        <h1>Group Generator</h1>
+        <form className="make-groups-page__form" onSubmit={this.handleSubmit}>
+          <fieldset>
+            <legend>Grouping characteristics:</legend>
+            <label htmlFor="group-size">Group size (minimum):</label>
+            <input
+              name="group-size"
+              id="group-size"
+              type="number"
+              min="2"
+              max="20"
+              defaultValue="2"
+              onChange={this.updateGroupSize}
+            />
+            <div>
+              <input
+                name="grouping-type"
+                id="grouping-similar"
+                value="similar"
+                type="radio"
+                checked={this.state.groupingType === 'similar'}
+                onChange={this.updateGroupingType}
+                required
+              />
+              <label htmlFor="grouping-similar">Group members are similar</label>
+              <input
+                name="grouping-type"
+                id="grouping-mixed"
+                value="mixed"
+                type="radio"
+                checked={this.state.groupingType === 'mixed'}
+                onChange={this.updateGroupingType}
+              />
+              <label htmlFor="grouping-mixed">Group members are diverse</label>
+            </div>
+          </fieldset>
+          <div className="make-groups-page__form--student-data">
+            <fieldset>
+              <legend>Alias (list of names or other identifier):</legend>
+              <div>
+                <ValidationError message={this.validateAliases()} />
+                <ValidationError message={this.validateDataSize()} />
+              </div>
+              <textarea
+                id="aliases"
+                name="aliases"
+                rows="26"
+                columns="20"
+                placeholder="Enter aliases here, one on each line."
+                value={this.state.aliases}
+                onChange={this.updateAliases}
+              />
+            </fieldset>
+            <fieldset>
+              <legend>Primary category:</legend>
+              <div
+                onDragOver={(event) => this.onDragOver(event)}
+                onDrop={this.onDrop}
+              >
+                Click and drag to switch primary and secondary category.
+                {primaryCategory}
+              </div>
+            </fieldset>
+            <fieldset>
+              <legend>Secondary category:</legend>
+              <div
+                onDragOver={(event) => this.onDragOver(event)}
+                onDrop={this.onDrop}
+              >
+                Click and drag to switch primary and secondary category.
+                {secondaryCategory}
+              </div>
+            </fieldset>
+          </div>
           <div>
             <ValidationError message={this.validateTextareaLines()} />
           </div>
@@ -416,7 +584,7 @@ class MakeGroupsPage extends Component {
               Generate Groups
           </button>
           </div>
-      </form>
+        </form>
       </main>
     );
   }

--- a/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
+++ b/src/routes/MakeGroupsPage/MakeGroupsPage.jsx
@@ -41,7 +41,7 @@ class MakeGroupsPage extends Component {
 
   handleSubmit = (e) => {
     e.preventDefault();
-    const { addData, addStudentArr } = this.context;
+    const { addData, addStudentArr, addCatNames } = this.context;
     const { history } = this.props;
     const {
       groupSize,
@@ -101,11 +101,13 @@ class MakeGroupsPage extends Component {
     if (groupingType === 'mixed') {
       const groups = createDifferentGroups(mixedStudentArray, groupSize, primaryCatName, secondaryCatName);
       this.addGroupNum(groups, mixedStudentArray);
+      addCatNames(primaryCatName, secondaryCatName);
       addStudentArr(mixedStudentArray);
     }
     if (groupingType === 'similar') {
       const groups = createSimilarGroups(mixedStudentArray, groupSize, primaryCatName, secondaryCatName);
       this.addGroupNum(groups, mixedStudentArray);
+      addCatNames(primaryCatName, secondaryCatName);
       addStudentArr(mixedStudentArray);
     }
     history.push('/groups-made')

--- a/src/routes/SavedGroupsPage/SavedGroupsPage.css
+++ b/src/routes/SavedGroupsPage/SavedGroupsPage.css
@@ -1,0 +1,3 @@
+.saved-groups-page {
+  height: 100vh;
+}

--- a/src/routes/SavedGroupsPage/SavedGroupsPage.css
+++ b/src/routes/SavedGroupsPage/SavedGroupsPage.css
@@ -1,3 +1,43 @@
 .saved-groups-page {
   height: 100vh;
+  margin: 0 auto;
+}
+
+.drag-container {
+  text-align: center;
+}
+
+.head {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+  background-color: gray;
+  width: 100%;
+}
+
+.droppable {
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  right: 0;
+  top: 10;
+  background-color: #9E9E9E;
+  border-left: 2px dotted red;
+}
+
+.draggable {
+  width: 100px;
+  height: 100px;
+  background-color: yellow;
+  margin: 10px auto;
+}
+
+.inProgress {
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  left: 0;
+  top: 10;
+  background-color: #EEEEEE;
+  border-right: 2px dotted red;
 }

--- a/src/routes/SavedGroupsPage/SavedGroupsPage.jsx
+++ b/src/routes/SavedGroupsPage/SavedGroupsPage.jsx
@@ -2,10 +2,79 @@ import React, { Component } from 'react';
 import './SavedGroupsPage.css';
 
 class SavedGroupsPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tasks: [
+        {id: "1", taskName:"Read book",type:"inProgress", backgroundColor: "red"},
+        {id: "2", taskName:"Pay bills", type:"inProgress", backgroundColor:"green"},
+        {id: "3", taskName:"Go to the gym", type:"Done", backgroundColor:"blue"},
+        {id: "4", taskName:"Play baseball", type:"Done", backgroundColor:"green"}
+    ]
+    }
+  }
+
+  onDragStart = (event, taskName) => {
+    console.log('dragstart on div: ', taskName);
+    event.dataTransfer.setData("taskName", taskName);
+  }
+
+  onDragOver = (event) => {
+    event.preventDefault();
+  }
+
+  onDrop = (event, cat) => {
+    let taskName = event.dataTransfer.getData("taskName");
+    let tasks = this.state.tasks.filter((task) => {
+      if (task.taskName === taskName) {
+        task.type = cat;
+      }
+      return task;
+    })
+    this.setState({ ...this.state, tasks });
+  }
+
   render() {
+    const tasks = {
+      inProgress: [],
+      Done: [],
+    }
+
+    this.state.tasks.forEach((task) => {
+      tasks[task.type].push(
+        <div 
+          key={task.id}
+          onDragStart={(event) => this.onDragStart(event, task.taskName)}
+          draggable
+          className="draggable" 
+          style={{backgroundColor: task.backgroundColor}}
+        >
+          {task.taskName}
+        </div>
+      )
+    })
     return (
       <main className="saved-groups-page">
         Saved Groups Page
+        <div className="drag-container">
+          <h2 className="head">To Do List Drag & Drop</h2>
+          <div 
+            className="inProgress"
+            onDragOver={(event) => this.onDragOver(event)}
+            onDrop={(event) => {this.onDrop(event, "inProgress")}}
+          >
+            <span className="group-header">In Progress</span>
+            {tasks.inProgress}
+          </div>
+          <div
+            className="droppable"
+            onDragOver={(event) => this.onDragOver(event)}
+            onDrop={(event) => this.onDrop(event, "Done")}
+          >
+            <span className="group-header">Done</span>
+            {tasks.Done}
+          </div>
+        </div>
       </main>
     )
   }

--- a/src/routes/SavedGroupsPage/SavedGroupsPage.jsx
+++ b/src/routes/SavedGroupsPage/SavedGroupsPage.jsx
@@ -40,6 +40,8 @@ class SavedGroupsPage extends Component {
       Done: [],
     }
 
+    console.log(tasks);
+
     this.state.tasks.forEach((task) => {
       tasks[task.type].push(
         <div 

--- a/src/routes/SavedGroupsPage/SavedGroupsPage.jsx
+++ b/src/routes/SavedGroupsPage/SavedGroupsPage.jsx
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import './SavedGroupsPage.css';
+
+class SavedGroupsPage extends Component {
+  render() {
+    return (
+      <main className="saved-groups-page">
+        Saved Groups Page
+      </main>
+    )
+  }
+}
+
+export default SavedGroupsPage;

--- a/src/services/groupingAlgorithms/differentGroups.js
+++ b/src/services/groupingAlgorithms/differentGroups.js
@@ -2,7 +2,7 @@
 // so that the students belonging to the most common categories appear first
 
 function createDifferentGroups(arr, groupSize, primaryCatKey, secondaryCatKey) {
-  let pool = arr;
+  let pool = [...arr];
   let groups = [];
   let lastGroupPrimaryCats = [];
   let lastGroupSecondaryCats = [];

--- a/src/services/groupingAlgorithms/similarGroups.js
+++ b/src/services/groupingAlgorithms/similarGroups.js
@@ -1,5 +1,5 @@
 function createSimilarGroups(arr, groupSize, primaryCatKey, secondaryCatKey) {
-  let pool = arr;
+  let pool = [...arr];
   let groups = [];
   let lastGroupPrimaryCats = [];
   let lastGroupSecondaryCats = [];


### PR DESCRIPTION
Rewrote large portions of the app to accommodate drag and drop in:
-MakeGroupsPage, to make primary and secondary categories drag and drop (to switch them around easily)
-GroupsMadePage, to drag and drop students into different groups

This also involved a different approach to rendering the groups on the page: instead of rendering from nested arrays (innermost array is each group), groups are rendered from the original array of student objects, which now contains a groupNum property for each student.